### PR TITLE
fix(SEC-815): expose minimum_protocol_version variable, default to TLSv1.2_2021

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -181,7 +181,7 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
     content {
       acm_certificate_arn      = data.aws_acm_certificate.acm_cert[0].arn
       ssl_support_method       = "sni-only"
-      minimum_protocol_version = "TLSv1"
+      minimum_protocol_version = var.minimum_protocol_version
     }
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -54,3 +54,7 @@ variable "s3_sse_configuration" {
   }
   description = "s3 server side encryption configuration"
 }
+variable "minimum_protocol_version" {
+  default     = "TLSv1.2_2021"
+  description = "Minimum TLS protocol version for CloudFront viewer certificate"
+}


### PR DESCRIPTION
## Summary

- Adds `minimum_protocol_version` as a configurable variable (default: `TLSv1.2_2021`)
- Replaces the hardcoded `"TLSv1"` in the `viewer_certificate` block with `var.minimum_protocol_version`
- Callers that don't pass the variable will automatically get `TLSv1.2_2021` (secure default)

## Context

SEC-815 identified that CloudFront distributions using this module were offering TLS 1.0/1.1 and weak ciphers (3DES/IDEA). The `TLSv1.2_2021` policy enforces TLS 1.2+ and removes those ciphers.

## Merge order

Merge this PR **before** the companion workstream-terraform PR (#2304) so Atlantis can resolve the new variable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)